### PR TITLE
Freeze minio version equal to the cloud one

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - PYTHONUNBUFFERED=1
 
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2021-09-15T04-54-25Z
     ports:
       - "9000:9000"
       - "9001:9001"


### PR DESCRIPTION
# Description

Freeze minio version in order to be equal to the version deployed in the cloud

## Type of change

Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules